### PR TITLE
feat: refine header interactions and admin moderation

### DIFF
--- a/src/app/_components/home-header.tsx
+++ b/src/app/_components/home-header.tsx
@@ -1,18 +1,22 @@
 'use client'
 
-import { AppUser } from '@/types/microblog'
+import { useEffect, useRef } from 'react'
+
+import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import { Badge } from '@/components/ui/badge'
-import { ArrowUp, LogIn, MessageCircle, Search, X } from 'lucide-react'
+import { AppUser } from '@/types/microblog'
+import { LogIn, MessageCircle, Search, X } from 'lucide-react'
 
 interface HomeHeaderProps {
   searchTerm: string
   isSearching: boolean
   user: AppUser | null
+  isSearchVisible: boolean
   showScrollTop: boolean
   onSearchChange: (term: string) => void
   onSearchClick: () => void
+  onToggleSearch: () => void
   onClearSearch: () => void
   onScrollTop: () => void
   onLoginClick: () => void
@@ -22,22 +26,42 @@ export default function HomeHeader({
   searchTerm,
   isSearching,
   user,
+  isSearchVisible,
   showScrollTop,
   onSearchChange,
   onSearchClick,
+  onToggleSearch,
   onClearSearch,
   onScrollTop,
   onLoginClick,
 }: HomeHeaderProps) {
+  const searchInputRef = useRef<HTMLInputElement | null>(null)
+
+  useEffect(() => {
+    if (isSearchVisible) {
+      const timer = window.setTimeout(() => {
+        searchInputRef.current?.focus()
+      }, 0)
+
+      return () => window.clearTimeout(timer)
+    }
+  }, [isSearchVisible])
+
   return (
     <header
-      className={`fixed inset-x-0 top-0 z-50 border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80 transition-shadow ${showScrollTop ? 'shadow-sm' : ''}`}
+      className={`fixed inset-x-0 top-0 z-50 border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80 transition-shadow ${showScrollTop ? 'shadow-sm cursor-pointer' : ''}`}
+      onClick={(event) => {
+        if (!showScrollTop) return
+        const target = event.target as HTMLElement
+        if (target.closest('[data-interactive="true"]')) return
+        onScrollTop()
+      }}
     >
       <div className="container mx-auto max-w-2xl px-4 sm:px-6 lg:px-8 py-2.5">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex items-center justify-between gap-3">
             <div className="flex items-center gap-3">
-              <div className="w-10 h-10 bg-primary/10 rounded-full flex items-center justify-center">
+              <div className="w-10 h-10 bg-primary/10 rounded-full flex items-center justify-center" data-interactive="true">
                 <MessageCircle className="w-5 h-5 text-primary" />
               </div>
               <div>
@@ -49,61 +73,68 @@ export default function HomeHeader({
                 </p>
               </div>
             </div>
-            {showScrollTop && (
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={onScrollTop}
-                className="sm:hidden"
-                aria-label="返回顶部"
-              >
-                <ArrowUp className="h-4 w-4" />
-              </Button>
-            )}
           </div>
           <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-end sm:gap-3">
-            <div className="flex w-full items-center gap-2 sm:flex-1">
-              <div className="relative flex-1 min-w-[160px]">
-                <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-                <Input
-                  type="text"
-                  placeholder="搜索内容..."
-                  value={searchTerm}
-                  onChange={(e) => onSearchChange(e.target.value)}
-                  className="h-9 rounded-full border-muted-foreground/20 bg-background/80 pl-10 pr-10 text-sm"
-                />
-                {searchTerm && (
+            <div className="flex w-full items-center justify-end gap-2 sm:flex-1 sm:justify-end">
+              {isSearchVisible ? (
+                <div className="flex w-full items-center gap-2 sm:w-auto" data-interactive="true">
+                  <div className="relative flex-1 min-w-[160px]">
+                    <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                    <Input
+                      ref={searchInputRef}
+                      type="text"
+                      placeholder="搜索内容..."
+                      value={searchTerm}
+                      onChange={(e) => onSearchChange(e.target.value)}
+                      className="h-9 rounded-full border-muted-foreground/20 bg-background/80 pl-10 pr-10 text-sm"
+                      data-interactive="true"
+                    />
+                    {searchTerm && (
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={onClearSearch}
+                        className="absolute right-1 top-1/2 h-6 w-6 -translate-y-1/2"
+                        data-interactive="true"
+                        aria-label="清除搜索"
+                      >
+                        <X className="h-3 w-3" />
+                      </Button>
+                    )}
+                  </div>
+                  <Button
+                    size="sm"
+                    className="h-9 rounded-full px-3 text-xs whitespace-nowrap"
+                    onClick={onSearchClick}
+                    data-interactive="true"
+                  >
+                    <Search className="mr-1 h-3 w-3" />
+                    搜索
+                  </Button>
                   <Button
                     variant="ghost"
                     size="icon"
-                    onClick={onClearSearch}
-                    className="absolute right-1 top-1/2 h-6 w-6 -translate-y-1/2"
+                    onClick={onToggleSearch}
+                    className="h-9 w-9"
+                    data-interactive="true"
+                    aria-label="收起搜索"
                   >
-                    <X className="h-3 w-3" />
+                    <X className="h-4 w-4" />
                   </Button>
-                )}
-              </div>
-              <Button
-                size="sm"
-                className="h-9 rounded-full px-3 text-xs whitespace-nowrap"
-                onClick={onSearchClick}
-              >
-                <Search className="mr-1 h-3 w-3" />
-                搜索
-              </Button>
-              {showScrollTop && (
+                </div>
+              ) : (
                 <Button
-                  variant="ghost"
-                  size="icon"
-                  onClick={onScrollTop}
-                  className="hidden sm:flex"
-                  aria-label="返回顶部"
+                  size="sm"
+                  className="h-9 rounded-full px-3 text-xs whitespace-nowrap"
+                  onClick={onToggleSearch}
+                  data-interactive="true"
                 >
-                  <ArrowUp className="h-4 w-4" />
+                  <Search className="mr-1 h-3 w-3" />
+                  搜索
                 </Button>
               )}
             </div>
-            <div className="flex items-center justify-between gap-2 sm:justify-end">
+            <div className="flex items-center justify-between gap-2 sm:justify-end" data-interactive="true">
               {isSearching && (
                 <Badge variant="secondary" className="w-fit rounded-full px-2 py-0.5 text-[11px]">
                   搜索结果: "{searchTerm}"
@@ -119,6 +150,7 @@ export default function HomeHeader({
                   size="sm"
                   className="h-9 rounded-full px-3 text-xs"
                   onClick={onLoginClick}
+                  data-interactive="true"
                 >
                   <LogIn className="mr-1 h-3 w-3" />
                   管理登录
@@ -131,3 +163,4 @@ export default function HomeHeader({
     </header>
   )
 }
+

--- a/src/app/_components/microblog-card.tsx
+++ b/src/app/_components/microblog-card.tsx
@@ -6,7 +6,7 @@ import remarkGfm from 'remark-gfm'
 import rehypeHighlight from 'rehype-highlight'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
-import { Heart, MessageCircle } from 'lucide-react'
+import { Heart, MessageCircle, Edit3, Trash2 } from 'lucide-react'
 import MonacoEditorWrapper from '@/components/ui/monaco-editor-wrapper'
 import { AppUser, GuestIdentity, Microblog } from '@/types/microblog'
 
@@ -17,6 +17,8 @@ interface MicroblogCardProps {
   commentLoading: boolean
   editing: boolean
   editingContent: string
+  editingComments: Record<string, boolean>
+  editingCommentContent: Record<string, string>
   user: AppUser | null
   getGuestInfo: (microblogId: string) => GuestIdentity
   formatTime: (dateString: string) => string
@@ -26,9 +28,16 @@ interface MicroblogCardProps {
   onCommentInputChange: (microblogId: string, value: string) => void
   onSubmitComment: (microblogId: string) => void
   onCommentGuestInfoChange: (microblogId: string, field: 'name' | 'email', value: string) => void
+  onStartEditing: (microblogId: string, content: string) => void
   onCancelEditing: (microblogId: string) => void
   onSaveEdit: (microblogId: string) => void
   onEditContentChange: (microblogId: string, value: string) => void
+  onDeleteMicroblog: (microblogId: string) => void
+  onStartEditComment: (microblogId: string, commentId: string, content: string) => void
+  onCancelEditComment: (commentId: string) => void
+  onEditCommentChange: (commentId: string, value: string) => void
+  onSaveEditComment: (microblogId: string, commentId: string) => void
+  onDeleteComment: (microblogId: string, commentId: string) => void
 }
 
 export default function MicroblogCard({
@@ -38,6 +47,8 @@ export default function MicroblogCard({
   commentLoading,
   editing,
   editingContent,
+  editingComments,
+  editingCommentContent,
   user,
   getGuestInfo,
   formatTime,
@@ -47,9 +58,16 @@ export default function MicroblogCard({
   onCommentInputChange,
   onSubmitComment,
   onCommentGuestInfoChange,
+  onStartEditing,
   onCancelEditing,
   onSaveEdit,
   onEditContentChange,
+  onDeleteMicroblog,
+  onStartEditComment,
+  onCancelEditComment,
+  onEditCommentChange,
+  onSaveEditComment,
+  onDeleteComment,
 }: MicroblogCardProps) {
   const guestInfo = getGuestInfo(microblog.id)
   const handleGuestKeyPress = (event: React.KeyboardEvent<HTMLInputElement>) => {
@@ -66,10 +84,36 @@ export default function MicroblogCard({
     }
   }
 
+  const canManageMicroblog = Boolean(
+    user?.isAdmin || (user && microblog.user && microblog.user.id === user.id),
+  )
+
   return (
     <Card className="hover:shadow-md transition-all duration-300 border-primary/10 hover:border-primary/20 bg-gradient-to-br from-background to-muted/5">
       <CardContent className="px-4 py-3 sm:px-5 sm:py-4">
-        <div className="mb-2.5">
+        <div className="mb-2.5 flex flex-col gap-2">
+          {canManageMicroblog && !editing && (
+            <div className="flex justify-end gap-2">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-8 px-2 text-xs"
+                onClick={() => onStartEditing(microblog.id, microblog.content)}
+              >
+                <Edit3 className="mr-1 h-3 w-3" />
+                编辑
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-8 px-2 text-xs text-destructive hover:text-destructive"
+                onClick={() => onDeleteMicroblog(microblog.id)}
+              >
+                <Trash2 className="mr-1 h-3 w-3" />
+                删除
+              </Button>
+            </div>
+          )}
           {editing ? (
             <div className="space-y-3">
               <MonacoEditorWrapper
@@ -161,16 +205,77 @@ export default function MicroblogCard({
             {microblog.comments.length > 0 && (
               <div className="space-y-2.5 mb-3 max-h-60 overflow-y-auto custom-scrollbar">
                 {microblog.comments.map((comment) => (
-                  <div key={comment.id} className="bg-muted/30 px-3 py-2.5 rounded-lg text-sm">
-                    <div className="flex items-center gap-2 mb-2">
-                      {comment.user ? (
-                        <span className="font-medium text-xs text-foreground">{comment.user.username}</span>
-                      ) : (
-                        <span className="font-medium text-xs text-foreground">{comment.guestName}</span>
+                  <div key={comment.id} className="bg-muted/30 px-3 py-2.5 rounded-lg text-sm space-y-2">
+                    <div className="flex items-start justify-between gap-2">
+                      <div className="flex flex-col">
+                        {comment.user ? (
+                          <span className="font-medium text-xs text-foreground">{comment.user.username}</span>
+                        ) : (
+                          <span className="font-medium text-xs text-foreground">{comment.guestName}</span>
+                        )}
+                      </div>
+                      {(user?.isAdmin || (comment.user && user?.id === comment.user.id)) && (
+                        <div className="flex items-center gap-1">
+                          {!editingComments[comment.id] && (
+                            <>
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                className="h-7 w-7"
+                                onClick={() =>
+                                  onStartEditComment(microblog.id, comment.id, comment.content)
+                                }
+                                aria-label="编辑评论"
+                              >
+                                <Edit3 className="h-3.5 w-3.5" />
+                              </Button>
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                className="h-7 w-7 text-destructive hover:text-destructive"
+                                onClick={() => onDeleteComment(microblog.id, comment.id)}
+                                aria-label="删除评论"
+                              >
+                                <Trash2 className="h-3.5 w-3.5" />
+                              </Button>
+                            </>
+                          )}
+                        </div>
                       )}
                     </div>
-                    <p className="text-foreground leading-relaxed">{comment.content}</p>
-                    <p className="text-xs text-muted-foreground mt-2">
+                    {editingComments[comment.id] ? (
+                      <div className="space-y-2">
+                        <textarea
+                          className="w-full rounded-md border border-border bg-background px-2.5 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
+                          rows={3}
+                          value={editingCommentContent[comment.id] || ''}
+                          onChange={(event) => onEditCommentChange(comment.id, event.target.value)}
+                        />
+                        <div className="flex justify-end gap-2">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="h-8 px-2 text-xs"
+                            onClick={() => onCancelEditComment(comment.id)}
+                          >
+                            取消
+                          </Button>
+                          <Button
+                            size="sm"
+                            className="h-8 px-3 text-xs"
+                            disabled={!editingCommentContent[comment.id]?.trim()}
+                            onClick={() => onSaveEditComment(microblog.id, comment.id)}
+                          >
+                            保存
+                          </Button>
+                        </div>
+                      </div>
+                    ) : (
+                      <p className="text-foreground leading-relaxed whitespace-pre-wrap break-words">
+                        {comment.content}
+                      </p>
+                    )}
+                    <p className="text-xs text-muted-foreground">
                       <span
                         className="cursor-help hover:text-foreground transition-colors"
                         title={`评论时间：${formatFullTime(comment.createdAt)}`}

--- a/src/app/_components/microblog-list.tsx
+++ b/src/app/_components/microblog-list.tsx
@@ -14,6 +14,8 @@ interface MicroblogListProps {
   commentLoading: Record<string, boolean>
   editingMicroblog: Record<string, boolean>
   editingContent: Record<string, string>
+  editingComments: Record<string, boolean>
+  editingCommentContent: Record<string, string>
   user: AppUser | null
   getGuestInfo: (microblogId: string) => GuestIdentity
   formatTime: (dateString: string) => string
@@ -23,9 +25,16 @@ interface MicroblogListProps {
   onCommentInputChange: (microblogId: string, value: string) => void
   onSubmitComment: (microblogId: string) => void
   onCommentGuestInfoChange: (microblogId: string, field: 'name' | 'email', value: string) => void
+  onStartEditing: (microblogId: string, content: string) => void
   onCancelEditing: (microblogId: string) => void
   onSaveEdit: (microblogId: string) => void
   onEditContentChange: (microblogId: string, value: string) => void
+  onDeleteMicroblog: (microblogId: string) => void
+  onStartEditComment: (microblogId: string, commentId: string, content: string) => void
+  onCancelEditComment: (commentId: string) => void
+  onEditCommentChange: (commentId: string, value: string) => void
+  onSaveEditComment: (microblogId: string, commentId: string) => void
+  onDeleteComment: (microblogId: string, commentId: string) => void
 }
 
 export default function MicroblogList({
@@ -37,6 +46,8 @@ export default function MicroblogList({
   commentLoading,
   editingMicroblog,
   editingContent,
+  editingComments,
+  editingCommentContent,
   user,
   getGuestInfo,
   formatTime,
@@ -46,9 +57,16 @@ export default function MicroblogList({
   onCommentInputChange,
   onSubmitComment,
   onCommentGuestInfoChange,
+  onStartEditing,
   onCancelEditing,
   onSaveEdit,
   onEditContentChange,
+  onDeleteMicroblog,
+  onStartEditComment,
+  onCancelEditComment,
+  onEditCommentChange,
+  onSaveEditComment,
+  onDeleteComment,
 }: MicroblogListProps) {
   return (
     <div className="space-y-3 sm:space-y-4">
@@ -88,6 +106,8 @@ export default function MicroblogList({
             commentLoading={Boolean(commentLoading[microblog.id])}
             editing={Boolean(editingMicroblog[microblog.id])}
             editingContent={editingContent[microblog.id] || ''}
+            editingComments={editingComments}
+            editingCommentContent={editingCommentContent}
             user={user}
             getGuestInfo={getGuestInfo}
             formatTime={formatTime}
@@ -97,9 +117,16 @@ export default function MicroblogList({
             onCommentInputChange={onCommentInputChange}
             onSubmitComment={onSubmitComment}
             onCommentGuestInfoChange={onCommentGuestInfoChange}
+            onStartEditing={onStartEditing}
             onCancelEditing={onCancelEditing}
             onSaveEdit={onSaveEdit}
             onEditContentChange={onEditContentChange}
+            onDeleteMicroblog={onDeleteMicroblog}
+            onStartEditComment={onStartEditComment}
+            onCancelEditComment={onCancelEditComment}
+            onEditCommentChange={onEditCommentChange}
+            onSaveEditComment={onSaveEditComment}
+            onDeleteComment={onDeleteComment}
           />
         ))
       )}

--- a/src/app/api/comments/[id]/route.ts
+++ b/src/app/api/comments/[id]/route.ts
@@ -1,0 +1,145 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+import { db } from '@/lib/db'
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params
+    const { content, userId } = await request.json()
+
+    if (!content || !content.trim()) {
+      return NextResponse.json({ error: 'Content is required' }, { status: 400 })
+    }
+
+    if (!userId) {
+      return NextResponse.json(
+        { error: 'User must be logged in to edit comment' },
+        { status: 401 },
+      )
+    }
+
+    const requestingUser = await db.user.findUnique({
+      where: { id: userId },
+      select: {
+        id: true,
+        isAdmin: true,
+      },
+    })
+
+    if (!requestingUser) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 })
+    }
+
+    const comment = await db.comment.findUnique({
+      where: { id },
+      include: {
+        user: {
+          select: {
+            id: true,
+            username: true,
+            isAdmin: true,
+          },
+        },
+      },
+    })
+
+    if (!comment) {
+      return NextResponse.json({ error: 'Comment not found' }, { status: 404 })
+    }
+
+    if (!requestingUser.isAdmin && comment.userId !== userId) {
+      return NextResponse.json(
+        { error: 'You can only edit your own comments' },
+        { status: 403 },
+      )
+    }
+
+    const updatedComment = await db.comment.update({
+      where: { id },
+      data: {
+        content: content.trim(),
+      },
+      include: {
+        user: {
+          select: {
+            id: true,
+            username: true,
+            isAdmin: true,
+          },
+        },
+      },
+    })
+
+    return NextResponse.json(updatedComment)
+  } catch (error) {
+    console.error('Error updating comment:', error)
+    return NextResponse.json(
+      { error: 'Failed to update comment' },
+      { status: 500 },
+    )
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { id } = await params
+    const { userId } = await request.json()
+
+    if (!userId) {
+      return NextResponse.json(
+        { error: 'User must be logged in to delete comment' },
+        { status: 401 },
+      )
+    }
+
+    const requestingUser = await db.user.findUnique({
+      where: { id: userId },
+      select: {
+        id: true,
+        isAdmin: true,
+      },
+    })
+
+    if (!requestingUser) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 })
+    }
+
+    const comment = await db.comment.findUnique({
+      where: { id },
+      select: {
+        id: true,
+        userId: true,
+      },
+    })
+
+    if (!comment) {
+      return NextResponse.json({ error: 'Comment not found' }, { status: 404 })
+    }
+
+    if (!requestingUser.isAdmin && comment.userId !== userId) {
+      return NextResponse.json(
+        { error: 'You can only delete your own comments' },
+        { status: 403 },
+      )
+    }
+
+    await db.comment.delete({
+      where: { id },
+    })
+
+    return NextResponse.json({ message: 'Comment deleted successfully' })
+  } catch (error) {
+    console.error('Error deleting comment:', error)
+    return NextResponse.json(
+      { error: 'Failed to delete comment' },
+      { status: 500 },
+    )
+  }
+}
+

--- a/src/app/api/microblogs/[id]/route.ts
+++ b/src/app/api/microblogs/[id]/route.ts
@@ -23,6 +23,18 @@ export async function PUT(
       )
     }
 
+    const requestingUser = await db.user.findUnique({
+      where: { id: userId },
+      select: {
+        id: true,
+        isAdmin: true,
+      },
+    })
+
+    if (!requestingUser) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 })
+    }
+
     // 检查微博是否存在
     const microblog = await db.microblog.findUnique({
       where: { id },
@@ -45,7 +57,7 @@ export async function PUT(
     }
 
     // 检查用户是否有权限编辑（只有作者可以编辑）
-    if (microblog.userId !== userId) {
+    if (!requestingUser.isAdmin && microblog.userId !== userId) {
       return NextResponse.json(
         { error: 'You can only edit your own microblogs' },
         { status: 403 }
@@ -109,6 +121,18 @@ export async function DELETE(
       )
     }
 
+    const requestingUser = await db.user.findUnique({
+      where: { id: userId },
+      select: {
+        id: true,
+        isAdmin: true,
+      },
+    })
+
+    if (!requestingUser) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 })
+    }
+
     // 检查微博是否存在
     const microblog = await db.microblog.findUnique({
       where: { id },
@@ -131,7 +155,7 @@ export async function DELETE(
     }
 
     // 检查用户是否有权限删除（只有作者可以删除）
-    if (microblog.userId !== userId) {
+    if (!requestingUser.isAdmin && microblog.userId !== userId) {
       return NextResponse.json(
         { error: 'You can only delete your own microblogs' },
         { status: 403 }


### PR DESCRIPTION
## Summary
- collapse the home header search experience behind a toggle, add focus handling, and make the header background act as a scroll-to-top trigger
- enable administrators to edit or delete published microblogs and comments with new UI controls and supporting state management
- allow server-side moderation by updating microblog authorization checks and adding comment edit/delete endpoints

## Testing
- pnpm lint *(warns about existing unused eslint-disable directive in src/hooks/use-toast.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d6637b05008323b35cdb7049c9dcc0