### PR TITLE
Enhance admin header status and media interactions

### DIFF
--- a/src/app/_components/home-header.tsx
+++ b/src/app/_components/home-header.tsx
@@ -5,8 +5,9 @@ import { useEffect, useRef } from 'react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { Avatar, AvatarFallback } from '@/components/ui/avatar'
 import { AppUser } from '@/types/microblog'
-import { LogIn, MessageCircle, Search, X } from 'lucide-react'
+import { LogIn, LogOut, MessageCircle, Search, ShieldCheck, User2, X } from 'lucide-react'
 
 interface HomeHeaderProps {
   searchTerm: string
@@ -20,6 +21,7 @@ interface HomeHeaderProps {
   onClearSearch: () => void
   onScrollTop: () => void
   onLoginClick: () => void
+  onLogoutClick: () => void
 }
 
 export default function HomeHeader({
@@ -34,6 +36,7 @@ export default function HomeHeader({
   onClearSearch,
   onScrollTop,
   onLoginClick,
+  onLogoutClick,
 }: HomeHeaderProps) {
   const searchInputRef = useRef<HTMLInputElement | null>(null)
 
@@ -141,9 +144,41 @@ export default function HomeHeader({
                 </Badge>
               )}
               {user ? (
-                <Badge variant="outline" className="hidden sm:inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-[11px]">
-                  {user.isAdmin ? '管理员已登录' : `${user.username}`}
-                </Badge>
+                <div className="flex items-center gap-2 rounded-full border border-border/60 bg-muted/30 px-2.5 py-1 shadow-sm">
+                  <Avatar className="h-8 w-8 border border-primary/30">
+                    <AvatarFallback className="bg-primary/10 text-xs font-semibold text-primary">
+                      {user.username.slice(0, 1).toUpperCase()}
+                    </AvatarFallback>
+                  </Avatar>
+                  <span className="text-[11px] font-medium text-muted-foreground sm:hidden">
+                    {user.isAdmin ? '管理员' : '已登录'}
+                  </span>
+                  <div className="hidden text-left sm:flex sm:flex-col sm:leading-tight">
+                    <span className="text-xs font-medium text-foreground">{user.username}</span>
+                    <span className="flex items-center gap-1 text-[11px] text-muted-foreground">
+                      {user.isAdmin ? (
+                        <>
+                          <ShieldCheck className="h-3.5 w-3.5 text-primary" />
+                          管理员
+                        </>
+                      ) : (
+                        <>
+                          <User2 className="h-3.5 w-3.5" />访客
+                        </>
+                      )}
+                    </span>
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-8 px-2 text-xs text-muted-foreground hover:text-foreground"
+                    onClick={onLogoutClick}
+                    data-interactive="true"
+                  >
+                    <LogOut className="mr-1 h-3.5 w-3.5" />
+                    退出
+                  </Button>
+                </div>
               ) : (
                 <Button
                   variant="outline"

--- a/src/app/_components/microblog-card.tsx
+++ b/src/app/_components/microblog-card.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React from 'react'
+import React, { useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import rehypeHighlight from 'rehype-highlight'
@@ -9,6 +9,8 @@ import { Button } from '@/components/ui/button'
 import { Heart, MessageCircle, Edit3, Trash2 } from 'lucide-react'
 import MonacoEditorWrapper from '@/components/ui/monaco-editor-wrapper'
 import { AppUser, GuestIdentity, Microblog } from '@/types/microblog'
+import { Dialog, DialogContent } from '@/components/ui/dialog'
+import { cn } from '@/lib/utils'
 
 interface MicroblogCardProps {
   microblog: Microblog
@@ -70,6 +72,7 @@ export default function MicroblogCard({
   onDeleteComment,
 }: MicroblogCardProps) {
   const guestInfo = getGuestInfo(microblog.id)
+  const [previewImage, setPreviewImage] = useState<{ url: string; altText: string } | null>(null)
   const handleGuestKeyPress = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.key === 'Enter' && !event.shiftKey) {
       event.preventDefault()
@@ -161,14 +164,25 @@ export default function MicroblogCard({
             }`}
           >
             {microblog.images.map((image) => (
-              <div key={image.id} className="relative group overflow-hidden rounded-lg">
+              <button
+                key={image.id}
+                type="button"
+                onClick={() => setPreviewImage({ url: image.url, altText: image.altText })}
+                className={cn(
+                  'relative group overflow-hidden rounded-lg focus:outline-none',
+                  'focus-visible:ring-2 focus-visible:ring-primary/60',
+                )}
+                aria-label="查看大图"
+              >
                 <img
                   src={image.url}
                   alt={image.altText}
                   className="w-full h-40 sm:h-48 object-cover transition-transform duration-300 group-hover:scale-105"
                 />
-                <div className="absolute inset-0 bg-black/0 group-hover:bg-black/10 transition-colors duration-300"></div>
-              </div>
+                <div className="absolute inset-0 flex items-center justify-center bg-black/0 text-xs font-medium text-white transition-all duration-300 group-hover:bg-black/40 group-hover:text-white">
+                  <span className="opacity-0 group-hover:opacity-100">点击查看大图</span>
+                </div>
+              </button>
             ))}
           </div>
         )}
@@ -361,6 +375,27 @@ export default function MicroblogCard({
           </div>
         )}
       </CardContent>
+
+      <Dialog
+        open={Boolean(previewImage)}
+        onOpenChange={(open) => {
+          if (!open) {
+            setPreviewImage(null)
+          }
+        }}
+      >
+        <DialogContent className="sm:max-w-3xl border-none bg-background/95 p-0 shadow-xl">
+          {previewImage ? (
+            <div className="flex max-h-[80vh] w-full items-center justify-center bg-black">
+              <img
+                src={previewImage.url}
+                alt={previewImage.altText}
+                className="max-h-[80vh] w-full object-contain"
+              />
+            </div>
+          ) : null}
+        </DialogContent>
+      </Dialog>
     </Card>
   )
 }

--- a/src/components/ui/message-box.tsx
+++ b/src/components/ui/message-box.tsx
@@ -1,0 +1,93 @@
+'use client'
+
+import { ReactNode } from 'react'
+
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { AlertTriangle } from 'lucide-react'
+
+type MessageBoxVariant = 'default' | 'destructive'
+
+interface MessageBoxProps {
+  open: boolean
+  title: string
+  description?: string
+  confirmText?: string
+  cancelText?: string
+  loading?: boolean
+  icon?: ReactNode
+  variant?: MessageBoxVariant
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+export function MessageBox({
+  open,
+  title,
+  description,
+  confirmText = '确认',
+  cancelText = '取消',
+  loading = false,
+  icon,
+  variant = 'default',
+  onConfirm,
+  onCancel,
+}: MessageBoxProps) {
+  const iconStyles =
+    variant === 'destructive'
+      ? 'bg-destructive/10 text-destructive'
+      : 'bg-primary/10 text-primary'
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) {
+          onCancel()
+        }
+      }}
+    >
+      <DialogContent className="sm:max-w-md" showCloseButton={false}>
+        <DialogHeader className="items-center text-center">
+          <div className={`flex h-12 w-12 items-center justify-center rounded-full ${iconStyles}`}>
+            {icon ?? <AlertTriangle className="h-6 w-6" />}
+          </div>
+          <DialogTitle className="text-xl font-semibold text-foreground">{title}</DialogTitle>
+          {description ? (
+            <DialogDescription className="text-sm text-muted-foreground">
+              {description}
+            </DialogDescription>
+          ) : null}
+        </DialogHeader>
+        <DialogFooter className="sm:justify-center">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onCancel}
+            disabled={loading}
+            className="w-full sm:w-auto"
+          >
+            {cancelText}
+          </Button>
+          <Button
+            type="button"
+            variant={variant === 'destructive' ? 'destructive' : 'default'}
+            onClick={onConfirm}
+            disabled={loading}
+            className="w-full sm:w-auto"
+          >
+            {loading ? '处理中...' : confirmText}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+


### PR DESCRIPTION
## Summary
- integrate admin login status and logout control directly into the home header
- add a reusable message box dialog and apply it to logout and microblog deletion confirmations
- allow microblog images to open in a modal preview when clicked

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d669a8e96883239b569a8b3fa6fe3f