### PR TITLE
fix: improve markdown image uploads

### DIFF
--- a/src/app/_components/create-microblog-card.tsx
+++ b/src/app/_components/create-microblog-card.tsx
@@ -5,11 +5,21 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import LexicalEditor from '@/components/ui/lexical-editor'
-import { Image as ImageIcon, Send } from 'lucide-react'
+import { Image as ImageIcon, Loader2, Send, TriangleAlert } from 'lucide-react'
+
+export interface SelectedImageItem {
+  id: string
+  file?: File
+  previewUrl: string
+  remoteUrl?: string
+  alt: string
+  uploading: boolean
+  uploadError?: boolean
+}
 
 interface CreateMicroblogCardProps {
   content: string
-  selectedImages: Array<{ file: File; url: string; alt: string }>
+  selectedImages: SelectedImageItem[]
   isSubmitting: boolean
   formatFullTime: (dateString: string) => string
   onContentChange: (value: string) => void
@@ -28,7 +38,8 @@ export default function CreateMicroblogCard({
   onRemoveImage,
   onSubmit,
 }: CreateMicroblogCardProps) {
-  const canSubmit = Boolean(content.trim() || selectedImages.length)
+  const hasPendingUploads = selectedImages.some((image) => image.uploading)
+  const canSubmit = Boolean(content.trim() || selectedImages.length) && !hasPendingUploads
 
   return (
     <Card className="mb-3 sm:mb-4 shadow-md border-primary/20 hover:shadow-lg transition-all duration-300">
@@ -81,19 +92,23 @@ export default function CreateMicroblogCard({
           <div className="grid grid-cols-2 sm:grid-cols-3 gap-2.5 p-3 bg-muted/30 rounded-lg">
             {selectedImages.map((preview, index) => (
               <div
-                key={preview.url}
+                key={preview.id}
                 className="relative group"
-                draggable
+                draggable={!preview.uploading && !preview.uploadError}
                 onDragStart={(event) => {
+                  if (!preview.remoteUrl) {
+                    event.preventDefault()
+                    return
+                  }
                   event.dataTransfer.setData(
                     'text/plain',
-                    `![${preview.alt || '图片'}](${preview.url} "${preview.alt || ''}")`
+                    `![${preview.alt || '图片'}](${preview.remoteUrl} "${preview.alt || ''}")`
                   )
                   event.dataTransfer.effectAllowed = 'copy'
                 }}
               >
                 <img
-                  src={preview.url}
+                  src={preview.remoteUrl ?? preview.previewUrl}
                   alt={preview.alt || `预览 ${index + 1}`}
                   className="w-full h-20 sm:h-24 object-cover rounded-lg border-2 border-border group-hover:border-primary/40 transition-colors"
                 />
@@ -105,6 +120,16 @@ export default function CreateMicroblogCard({
                   ×
                 </button>
                 <div className="absolute inset-0 bg-black/20 rounded-lg opacity-0 group-hover:opacity-100 transition-opacity"></div>
+                {preview.uploading && (
+                  <div className="absolute inset-0 flex items-center justify-center bg-background/60 text-primary">
+                    <Loader2 className="h-5 w-5 animate-spin" />
+                  </div>
+                )}
+                {preview.uploadError && !preview.uploading && (
+                  <div className="absolute inset-x-0 bottom-0 flex items-center justify-center gap-1 bg-destructive/90 text-destructive-foreground py-1 text-[10px] font-semibold">
+                    <TriangleAlert className="h-3 w-3" /> 上传失败
+                  </div>
+                )}
               </div>
             ))}
           </div>

--- a/src/app/_components/microblog-card.tsx
+++ b/src/app/_components/microblog-card.tsx
@@ -6,8 +6,7 @@ import remarkGfm from 'remark-gfm'
 import rehypeHighlight from 'rehype-highlight'
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
-import { Heart, MessageCircle, Edit3, Trash2 } from 'lucide-react'
-import MonacoEditorWrapper from '@/components/ui/monaco-editor-wrapper'
+import { Heart, MessageCircle, Edit3, Trash2, Loader2, TriangleAlert } from 'lucide-react'
 import LexicalEditor from '@/components/ui/lexical-editor'
 import { AppUser, GuestIdentity, Microblog } from '@/types/microblog'
 import { Dialog, DialogContent } from '@/components/ui/dialog'
@@ -18,6 +17,10 @@ export interface EditableImage {
   url: string
   altText?: string | null
   file?: File
+  previewUrl?: string
+  uploading?: boolean
+  uploadError?: boolean
+  tempId?: string
 }
 
 interface MicroblogCardProps {
@@ -99,6 +102,10 @@ export default function MicroblogCard({
     altText: string | undefined | null,
     url: string,
   ) => {
+    if (!url) {
+      event.preventDefault()
+      return
+    }
     const markdown = `![${altText || '图片'}](${url})`
     event.dataTransfer.setData('text/plain', markdown)
     event.dataTransfer.effectAllowed = 'copy'
@@ -132,11 +139,11 @@ export default function MicroblogCard({
           )}
           {editing ? (
             <div className="space-y-3">
-              <MonacoEditorWrapper
+              <LexicalEditor
                 value={editingContent}
                 onChange={(value) => onEditContentChange(microblog.id, value)}
+                placeholder="编辑微博内容..."
                 height="120px"
-                language="markdown"
               />
               <div className="space-y-2">
                 <div className="flex items-center justify-between">
@@ -167,15 +174,15 @@ export default function MicroblogCard({
                   <div className="grid grid-cols-2 sm:grid-cols-3 gap-2.5">
                     {editingImages.map((image, index) => (
                       <div
-                        key={image.id ?? `${image.url}-${index}`}
+                        key={image.id ?? image.tempId ?? `${image.url}-${index}`}
                         className="relative group"
-                        draggable
+                        draggable={!image.uploading && !image.uploadError && Boolean(image.url)}
                         onDragStart={(event) =>
                           handleImageDragStart(event, image.altText, image.url)
                         }
                       >
                         <img
-                          src={image.url}
+                          src={image.url || image.previewUrl || ''}
                           alt={image.altText || `编辑图片 ${index + 1}`}
                           className="w-full h-24 object-cover rounded-lg border border-border/60"
                         />
@@ -187,10 +194,20 @@ export default function MicroblogCard({
                         >
                           ×
                         </button>
-                        {image.file && (
+                        {!image.id && !image.uploadError && (
                           <span className="absolute bottom-1 left-1 rounded bg-primary px-1.5 py-0.5 text-[10px] font-semibold text-primary-foreground shadow-sm">
                             新
                           </span>
+                        )}
+                        {image.uploading && (
+                          <div className="absolute inset-0 flex items-center justify-center bg-background/60 text-primary">
+                            <Loader2 className="h-5 w-5 animate-spin" />
+                          </div>
+                        )}
+                        {image.uploadError && !image.uploading && (
+                          <div className="absolute inset-x-0 bottom-0 flex items-center justify-center gap-1 bg-destructive/90 text-destructive-foreground py-1 text-[10px] font-semibold">
+                            <TriangleAlert className="h-3 w-3" /> 上传失败
+                          </div>
                         )}
                       </div>
                     ))}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,7 @@ import { ChangeEvent, useEffect, useState } from 'react'
 import 'highlight.js/styles/github.css'
 import LoginModal from '@/components/auth/login-modal'
 import HomeHeader from './_components/home-header'
-import CreateMicroblogCard from './_components/create-microblog-card'
+import CreateMicroblogCard, { SelectedImageItem } from './_components/create-microblog-card'
 import MicroblogList from './_components/microblog-list'
 import { AppUser, GuestIdentity, Microblog } from '@/types/microblog'
 import type { EditableImage } from './_components/microblog-card'
@@ -13,7 +13,7 @@ import { LogOut, Trash2 } from 'lucide-react'
 
 export default function Home() {
   const [content, setContent] = useState('')
-  const [selectedImages, setSelectedImages] = useState<Array<{ file: File; url: string; alt: string }>>([])
+  const [selectedImages, setSelectedImages] = useState<SelectedImageItem[]>([])
   const [microblogs, setMicroblogs] = useState<Microblog[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [commentInputs, setCommentInputs] = useState<Record<string, string>>({})
@@ -41,10 +41,34 @@ export default function Home() {
   const [microblogToDelete, setMicroblogToDelete] = useState<string | null>(null)
   const [isDeletingMicroblog, setIsDeletingMicroblog] = useState(false)
 
+  const generateClientId = () => {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      return crypto.randomUUID()
+    }
+    return `${Date.now()}-${Math.random().toString(16).slice(2)}`
+  }
+
+  const uploadImageFile = async (file: File) => {
+    const formData = new FormData()
+    formData.append('image', file)
+
+    const response = await fetch('/api/upload', {
+      method: 'POST',
+      body: formData,
+    })
+
+    if (!response.ok) {
+      throw new Error('Upload failed')
+    }
+
+    const data = await response.json()
+    return data.url as string
+  }
+
   const revokeEditingImageUrls = (images: EditableImage[]) => {
     images.forEach((image) => {
-      if (image.file) {
-        URL.revokeObjectURL(image.url)
+      if (image.previewUrl) {
+        URL.revokeObjectURL(image.previewUrl)
       }
     })
   }
@@ -179,19 +203,53 @@ export default function Home() {
 
   const handleImageUpload = (event: ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(event.target.files || [])
-    const previews = files.map((file) => ({
+    if (!files.length) return
+
+    const additions = files.map((file) => ({
+      id: generateClientId(),
       file,
-      url: URL.createObjectURL(file),
-      alt: file.name
+      previewUrl: URL.createObjectURL(file),
+      remoteUrl: undefined,
+      alt: file.name,
+      uploading: true,
+      uploadError: false,
     }))
-    setSelectedImages((prev) => [...prev, ...previews])
+
+    setSelectedImages((prev) => [...prev, ...additions])
+
+    additions.forEach(async (item) => {
+      try {
+        const url = await uploadImageFile(item.file)
+        setSelectedImages((prev) =>
+          prev.map((image) =>
+            image.id === item.id
+              ? { ...image, remoteUrl: url, uploading: false, uploadError: false, file: undefined }
+              : image,
+          ),
+        )
+      } catch (error) {
+        console.error('Failed to upload image:', error)
+        setSelectedImages((prev) =>
+          prev.map((image) =>
+            image.id === item.id
+              ? { ...image, uploading: false, uploadError: true }
+              : image,
+          ),
+        )
+      }
+    })
+
+    event.target.value = ''
   }
 
   const removeImage = (index: number) => {
     setSelectedImages((prev) => {
       const target = prev[index]
-      if (target) {
-        URL.revokeObjectURL(target.url)
+      if (!target) {
+        return prev
+      }
+      if (target.previewUrl) {
+        URL.revokeObjectURL(target.previewUrl)
       }
       return prev.filter((_, i) => i !== index)
     })
@@ -200,6 +258,11 @@ export default function Home() {
   const handleSubmit = async () => {
     if (!content.trim() && selectedImages.length === 0) return
 
+    if (selectedImages.some((image) => image.uploading)) {
+      console.warn('Images are still uploading')
+      return
+    }
+
     if (!user || !user.isAdmin) {
       openLoginModal('admin')
       return
@@ -207,26 +270,6 @@ export default function Home() {
 
     setIsSubmitting(true)
     try {
-      const imageUrls = [] as { url: string; altText: string }[]
-      for (const preview of selectedImages) {
-        const { file } = preview
-        const formData = new FormData()
-        formData.append('image', file)
-
-        const response = await fetch('/api/upload', {
-          method: 'POST',
-          body: formData,
-        })
-
-        if (response.ok) {
-          const data = await response.json()
-          imageUrls.push({
-            url: data.url,
-            altText: file.name,
-          })
-        }
-      }
-
       const response = await fetch('/api/microblogs', {
         method: 'POST',
         headers: {
@@ -234,7 +277,12 @@ export default function Home() {
         },
         body: JSON.stringify({
           content: content.trim(),
-          images: imageUrls,
+          images: selectedImages
+            .filter((preview) => preview.remoteUrl && !preview.uploadError)
+            .map((preview) => ({
+              url: preview.remoteUrl as string,
+              altText: preview.alt,
+            })),
         }),
       })
 
@@ -242,7 +290,11 @@ export default function Home() {
         const newMicroblog = await response.json()
         setMicroblogs((prev) => [newMicroblog, ...prev])
         setContent('')
-        selectedImages.forEach((preview) => URL.revokeObjectURL(preview.url))
+        selectedImages.forEach((preview) => {
+          if (preview.previewUrl) {
+            URL.revokeObjectURL(preview.previewUrl)
+          }
+        })
         setSelectedImages([])
       } else {
         console.error('Failed to create microblog')
@@ -459,7 +511,9 @@ export default function Home() {
       [microblogId]: microblog?.images?.map((image) => ({
         id: image.id,
         url: image.url,
-        altText: image.altText ?? undefined
+        altText: image.altText ?? undefined,
+        uploading: false,
+        uploadError: false,
       })) || []
     }))
     setEditingImagesToDelete((prev) => ({ ...prev, [microblogId]: [] }))
@@ -551,16 +605,55 @@ export default function Home() {
   const handleEditImageUpload = (microblogId: string, files: File[]) => {
     if (!files.length) return
 
+    const additions: EditableImage[] = files.map((file) => ({
+      tempId: generateClientId(),
+      file,
+      url: '',
+      previewUrl: URL.createObjectURL(file),
+      altText: file.name,
+      uploading: true,
+      uploadError: false,
+    }))
+
     setEditingImages((prev) => {
       const current = prev[microblogId] || []
-      const additions = files.map((file) => ({
-        file,
-        url: URL.createObjectURL(file),
-        altText: file.name
-      }))
       return {
         ...prev,
-        [microblogId]: [...current, ...additions]
+        [microblogId]: [...current, ...additions],
+      }
+    })
+
+    additions.forEach(async (image) => {
+      try {
+        if (!image.file) return
+        const url = await uploadImageFile(image.file)
+        setEditingImages((prev) => {
+          const current = prev[microblogId] || []
+          return {
+            ...prev,
+            [microblogId]: current.map((item) =>
+              item.tempId && item.tempId === image.tempId
+                ? { ...item, url, uploading: false, uploadError: false, file: undefined }
+                : item,
+            ),
+          }
+        })
+        if (image.previewUrl) {
+          URL.revokeObjectURL(image.previewUrl)
+        }
+      } catch (error) {
+        console.error('Failed to upload image for editing', error)
+        setEditingImages((prev) => {
+          const current = prev[microblogId] || []
+          return {
+            ...prev,
+            [microblogId]: current.map((item) =>
+              item.tempId && item.tempId === image.tempId
+                ? { ...item, uploading: false, uploadError: true }
+                : item,
+            ),
+          }
+        })
       }
     })
   }
@@ -576,8 +669,8 @@ export default function Home() {
         return prev
       }
 
-      if (removedImage.file) {
-        URL.revokeObjectURL(removedImage.url)
+      if (removedImage.previewUrl) {
+        URL.revokeObjectURL(removedImage.previewUrl)
       }
 
       const updatedImages = current.filter((_, i) => i !== index)
@@ -612,32 +705,19 @@ export default function Home() {
 
     const currentImages = editingImages[microblogId] || []
     const imagesMarkedForDeletion = editingImagesToDelete[microblogId] || []
-    const newImageFiles = currentImages.filter((image) => image.file)
-    const uploadedImages: { url: string; altText?: string }[] = []
+    if (currentImages.some((image) => image.uploading)) {
+      console.warn('Images are still uploading')
+      return
+    }
+
+    const uploadedImages = currentImages
+      .filter((image) => !image.id && image.url && !image.uploadError)
+      .map((image) => ({
+        url: image.url,
+        altText: image.altText ?? undefined,
+      }))
 
     try {
-      for (const image of newImageFiles) {
-        if (!image.file) continue
-
-        const formData = new FormData()
-        formData.append('image', image.file)
-
-        const uploadResponse = await fetch('/api/upload', {
-          method: 'POST',
-          body: formData,
-        })
-
-        if (uploadResponse.ok) {
-          const data = await uploadResponse.json()
-          uploadedImages.push({
-            url: data.url,
-            altText: image.file.name,
-          })
-        } else {
-          console.error('Failed to upload image for editing')
-        }
-      }
-
       const response = await fetch(`/api/microblogs/${microblogId}`, {
         method: 'PUT',
         headers: {

--- a/src/components/ui/lexical-editor.tsx
+++ b/src/components/ui/lexical-editor.tsx
@@ -74,7 +74,10 @@ export default function LexicalEditor({
             )}
             <MonacoEditorWrapper
               value={value}
-              onChange={onChange}
+              onChange={(nextValue) => {
+                const sanitizedValue = nextValue?.replace(/\$0/g, '') ?? ''
+                onChange?.(sanitizedValue)
+              }}
               height={height}
               language="markdown"
               withContainer={false}


### PR DESCRIPTION
## Summary
- upload selected images immediately, track upload state, and drag hosted URLs into the markdown composer
- reuse the markdown editor with preview for editing microblogs and strip stray `$0` markers from drops
- align edit image handling with immediate uploads, including upload/error indicators and payload updates

## Testing
- npm run lint *(fails: biome not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da38fa03e083239ffc4d5af76f5ac3